### PR TITLE
feature : Another way to update board subject

### DIFF
--- a/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/Board.kt
+++ b/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/Board.kt
@@ -15,8 +15,7 @@ import javax.persistence.Table
 class Board(
     subject: String,
 
-    @Column(name = "content", nullable = false)
-    var content: String,
+    content: String,
 
     @Column(name = "hits", nullable = false, updatable = true)
     var hits: Int? = 0,
@@ -28,15 +27,27 @@ class Board(
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     var member: Member,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_type_id", nullable = false, updatable = true)
-    var boardType: BoardType
+    boardType: BoardType
 ) : BaseEntity<Int>() {
     @Column(name = "subject", nullable = false)
     var subject: String = subject
 
-    fun updateSubject(newSubject: String): Board {
-        this.subject = newSubject
-        return this
+    @Column(name = "content", nullable = false)
+    var content: String = content
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_type_id", nullable = false, updatable = true)
+    var boardType: BoardType = boardType
+
+    fun updateBoard(updateBoardDto: UpdateBoardDto) {
+        updateBoardDto.subject?.let { this.subject = it }
+        updateBoardDto.content?.let { this.content = it }
+        updateBoardDto.boardType?.let { this.boardType = it }
     }
 }
+
+data class UpdateBoardDto(
+    val subject: String? = null,
+    val content: String? = null,
+    val boardType: BoardType? = null
+)

--- a/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/Board.kt
+++ b/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/Board.kt
@@ -13,8 +13,7 @@ import javax.persistence.Table
 @Entity
 @Table(name = "board_info")
 class Board(
-    @Column(name = "subject", nullable = false)
-    var subject: String,
+    subject: String,
 
     @Column(name = "content", nullable = false)
     var content: String,
@@ -32,4 +31,12 @@ class Board(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_type_id", nullable = false, updatable = true)
     var boardType: BoardType
-) : BaseEntity<Int>()
+) : BaseEntity<Int>() {
+    @Column(name = "subject", nullable = false)
+    var subject: String = subject
+
+    fun updateSubject(newSubject: String): Board {
+        this.subject = newSubject
+        return this
+    }
+}

--- a/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupport.kt
+++ b/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupport.kt
@@ -20,11 +20,4 @@ class BoardRepositorySupport(
             .where(board.id.eq(boardId))
             .fetchOne()
     }
-
-    fun updateSubject(boardId: Int, newSubject: String) {
-        jpaQueryFactory.update(board)
-            .where(board.id.eq(boardId))
-            .set(board.subject, newSubject)
-            .execute()
-    }
 }

--- a/demo-spring-data-jpa/src/test/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupportTest.kt
+++ b/demo-spring-data-jpa/src/test/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupportTest.kt
@@ -131,7 +131,9 @@ class BoardRepositorySupportTest {
 
         // when
         val newSubject = "새로운 테스트 제목"
-        board.updateSubject(newSubject)
+        board.updateBoard(
+            UpdateBoardDto(subject = newSubject)
+        )
 
         // then
         val boardId = board.id!!

--- a/demo-spring-data-jpa/src/test/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupportTest.kt
+++ b/demo-spring-data-jpa/src/test/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupportTest.kt
@@ -130,15 +130,15 @@ class BoardRepositorySupportTest {
         assertThat(board.subject).isEqualTo(subject)
 
         // when
-        val boardId = board.id!!
         val newSubject = "새로운 테스트 제목"
-        boardRepositorySupport.updateSubject(boardId, newSubject)
+        board.updateSubject(newSubject)
 
         // then
-        entityManager.clear()
+        val boardId = board.id!!
         val newBoard = boardRepositorySupport.findById(boardId)
         assertThat(newBoard).isNotNull
         assertThat(newBoard!!.subject).isEqualTo(newSubject)
+        assertThat(newBoard).isEqualTo(board)
     }
 
     @AfterEach


### PR DESCRIPTION
둘 중에 어느 방법이 나을지는 잘 모르겠다... 

- `Entity` 안에서 `updateSubject`로 `update`를 하는 방법
  - https://github.com/bossm0n5t3r/study/blob/feature/another-way-to-update/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/Board.kt#L38-L41
- `QuerydslRepositorySupport` 에서 `QBoard`, `update` method 를 통해서 `update` 하는 방법
  - https://github.com/bossm0n5t3r/study/blob/master/demo-spring-data-jpa/src/main/kotlin/com/example/demospringdatajpa/domain/board/BoardRepositorySupport.kt#L24-L29

---

첫 번째 방법은 결국 setter의 연장선인가... 지양해야하는 방법인 것인가... (https://cheese10yun.github.io/spring-jpa-best-06/)